### PR TITLE
Stop using SimpleSAML_Session::getInstance().

### DIFF
--- a/www/attributequery.php
+++ b/www/attributequery.php
@@ -1,6 +1,6 @@
 <?php
 
-$session = SimpleSAML_Session::getInstance();
+$session = SimpleSAML_Session::getSessionFromRequest();
 $metadata = SimpleSAML_Metadata_MetaDataStorageHandler::getMetadataHandler();
 
 if (!array_key_exists('StateId', $_REQUEST)) {


### PR DESCRIPTION
This method has been deprecated for a long time and is now removed. The new `getSessionFromRequest()` method must be used instead.
