### PR TITLE
SAML2 dependencia névtér + osztályváltozások

### DIFF
--- a/lib/Auth/Process/attributeaggregator.php
+++ b/lib/Auth/Process/attributeaggregator.php
@@ -37,7 +37,7 @@ class sspmod_attributeaggregator_Auth_Process_attributeaggregator extends Simple
 	 * nameIdFormat, the format of the attributeId. Default is "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent";
 	 * @var unknown_type
 	 */
-	private $nameIdFormat = SAML2_Const::NAMEID_PERSISTENT;
+	private $nameIdFormat = SAML2\Constants::NAMEID_PERSISTENT;
 
 
 	/**
@@ -93,10 +93,10 @@ class sspmod_attributeaggregator_Auth_Process_attributeaggregator extends Simple
 
 		if (!empty($config["nameIdFormat"])){
 			foreach (array(
-							SAML2_Const::NAMEID_UNSPECIFIED,
-							SAML2_Const::NAMEID_PERSISTENT,
-							SAML2_Const::NAMEID_TRANSIENT,
-							SAML2_Const::NAMEID_ENCRYPTED) as $format) {
+							SAML2\Constants::NAMEID_UNSPECIFIED,
+							SAML2\Constants::NAMEID_PERSISTENT,
+							SAML2\Constants::NAMEID_TRANSIENT,
+							SAML2\Constants::NAMEID_ENCRYPTED) as $format) {
 				$invalid = TRUE;
 				if ($config["nameIdFormat"] == $format) {
 					$this->nameIdFormat = $config["nameIdFormat"];
@@ -133,9 +133,9 @@ class sspmod_attributeaggregator_Auth_Process_attributeaggregator extends Simple
 
 		if (!empty($config["attributeNameFormat"])){
 			foreach (array(
-							SAML2_Const::NAMEFORMAT_UNSPECIFIED,
-							SAML2_Const::NAMEFORMAT_URI,
-							SAML2_Const::NAMEFORMAT_BASIC) as $format) {
+							SAML2\Constants::NAMEFORMAT_UNSPECIFIED,
+							SAML2\Constants::NAMEFORMAT_URI,
+							SAML2\Constants::NAMEFORMAT_BASIC) as $format) {
 				$invalid = TRUE;
 				if ($config["attributeNameFormat"] == $format) {
 					$this->attributeNameFormat = $config["attributeNameFormat"];

--- a/www/attributequery.php
+++ b/www/attributequery.php
@@ -17,7 +17,7 @@ $aaMetadata = $metadata->getMetadata($state['attributeaggregator:entityId'],'att
 /* Find an AttributeService with SOAP binding */
 $aas = $aaMetadata['AttributeService'];
 for ($i=0;$i<count($aas);$i++){
-	if ($aas[$i]['Binding'] == SAML2_Const::BINDING_SOAP){
+	if ($aas[$i]['Binding'] == SAML2\Constants::BINDING_SOAP){
 		$index = $i;
 		break;
 	}
@@ -85,7 +85,7 @@ try {
  /* Getting the response */
 SimpleSAML_Logger::debug('[attributeaggregator] attributequery - getting response');
 
-if (!($response instanceof SAML2_Response)) {
+if (!($response instanceof SAML2\Response)) {
 	throw new SimpleSAML_Error_Exception('Unexpected message received in response to the attribute query.');
 }
 
@@ -151,7 +151,7 @@ function sendQuery($dataId, $url, $nameId, $attributes, $attributeNameFormat,$sr
 
 	SimpleSAML_Logger::debug('[attributeaggregator] - sending request');
 
-	$query = new SAML2_AttributeQuery();
+	$query = new SAML2\AttributeQuery();
 	$query->setRelayState($dataId);
 	$query->setDestination($url);
 	$query->setIssuer($src->getValue('entityid'));
@@ -167,7 +167,7 @@ function sendQuery($dataId, $url, $nameId, $attributes, $attributeNameFormat,$sr
 	}
 	
 	SimpleSAML_Logger::debug('[attributeaggregator] - sending attribute query: '.var_export($query,1));
-	$binding = new SAML2_SOAPClient();
+	$binding = new SAML2\SOAPClient();
 
 	$result = $binding->send($query, $src, $dst);
 	return $result;


### PR DESCRIPTION
SimpleSAML frissítésnél (1.14 -> 1.15) a SAML2 dependenciánál megjelentek a nevterek ezert jonehany osztalyt atneveztek.
A hexaa-t használó szolgáltatások eldöglenek emiatt.
Köszi gyufi!